### PR TITLE
US04-Actions and Reducers for changing the current Player after a move

### DIFF
--- a/client/actions/Board/index.js
+++ b/client/actions/Board/index.js
@@ -1,5 +1,8 @@
 // Action Types
-import { PLAYER_MOVE } from 'actions/types';
+import { BOARD_ADD_PIECE } from 'actions/types';
+
+// Actions
+import { changePlayers } from 'actions/Players';
 
 export const addPiece = coordinate => (dispatch, getAppState) => {
   const {
@@ -12,11 +15,13 @@ export const addPiece = coordinate => (dispatch, getAppState) => {
   const topCell = cells.find(k => !!board[k]) || [0, 7];
   const coord = `${column}${parseInt(topCell[1], 10) - 1}`;
 
-  return dispatch({
-    type: PLAYER_MOVE,
+  dispatch({
+    type: BOARD_ADD_PIECE,
     payload: {
       coordinate: coord,
       color: currentPlayer
     }
   });
+
+  return dispatch(changePlayers());
 };

--- a/client/actions/Game/index.js
+++ b/client/actions/Game/index.js
@@ -1,5 +1,7 @@
 // Action Types
-import { GAME_END_GAME } from 'actions/types';
+import {
+  GAME_END_GAME
+} from 'actions/types';
 
 /**
  * Ends the game. Plain and simple.

--- a/client/actions/Players/index.js
+++ b/client/actions/Players/index.js
@@ -1,6 +1,7 @@
 // Action Types
 import {
-  PLAYER_SET_PLAYERS
+  PLAYER_SET_PLAYERS,
+  PLAYER_CHANGE_PLAYER
 } from 'actions/types';
 
 /**
@@ -18,5 +19,18 @@ export const setPlayers = player1Color => (dispatch) => {
       player2: player2Color,
       currentPlayer: player1Color
     }
+  });
+};
+
+/**
+ * Changes the current Players color. Changes who's turn it is to make a move.
+ */
+export const changePlayers = () => (dispatch, getAppState) => {
+  const { playersReducer: { currentPlayer } } = getAppState();
+  const newPlayer = currentPlayer === 'yellow' ? 'green' : 'yellow';
+
+  return dispatch({
+    type: PLAYER_CHANGE_PLAYER,
+    payload: newPlayer
   });
 };

--- a/client/actions/types.js
+++ b/client/actions/types.js
@@ -1,6 +1,6 @@
 // Players
 export const PLAYER_SET_PLAYERS = 'PLAYER_SET_PLAYERS';
-export const PLAYER_MOVE = 'PLAYER_MOVE';
+export const PLAYER_CHANGE_PLAYER = 'PLAYER_CHANGE_PLAYER';
 
 // Modals
 export const MODAL_CLOSE_MODAL = 'MODAL_CLOSE_MODAL';

--- a/client/reducers/Board/index.js
+++ b/client/reducers/Board/index.js
@@ -1,5 +1,5 @@
 // Action Types
-import { PLAYER_MOVE } from 'actions/types';
+import { BOARD_ADD_PIECE } from 'actions/types';
 
 const rows = Array(6).fill(null);
 const columns = 'abcdefg'.split('');
@@ -14,7 +14,7 @@ const initialState = columns.reduce((o, k) => ({
 
 const boardReducer = (state = initialState, action) => {
   switch (action.type) {
-    case PLAYER_MOVE:
+    case BOARD_ADD_PIECE:
       return {
         ...state,
         [action.payload.coordinate]: action.payload.color

--- a/client/reducers/Players/index.js
+++ b/client/reducers/Players/index.js
@@ -1,5 +1,8 @@
 // Action Types
-import { PLAYER_SET_PLAYERS } from 'actions/types';
+import {
+  PLAYER_SET_PLAYERS,
+  PLAYER_CHANGE_PLAYER
+} from 'actions/types';
 
 export const initialState = {
   player1: null,
@@ -15,6 +18,11 @@ const playersReducer = (state = initialState, action) => {
         player1: action.payload.player1,
         player2: action.payload.player2,
         currentPlayer: action.payload.currentPlayer
+      };
+    case PLAYER_CHANGE_PLAYER:
+      return {
+        ...state,
+        currentPlayer: action.payload
       };
     default:
       return state;


### PR DESCRIPTION
**Actions**:
  - Added `changePlayer` action to Player Actions
  - Updated `addPiece` action in Board Actions to dispatch new `changePlayer` action after a piece is added to the board

**Reducers**:
  - Added case to Player Reducer switch case for updating the current player when `changePlayer` action is dispatched